### PR TITLE
Add SensONE plugin

### DIFF
--- a/ethercat_plugins/ethercat_plugins.xml
+++ b/ethercat_plugins/ethercat_plugins.xml
@@ -59,4 +59,7 @@
   <class name="ethercat_plugins/Schneider_ATV320" type="ethercat_plugins::Schneider_ATV320" base_class_type="ethercat_interface::EcSlave">
     <description>Schneider Electric ATV320</description>
   </class>
+  <class name="ethercat_plugins/Bota_SensONE" type="ethercat_plugins::SensOneFtSensor" base_class_type="ethercat_interface::EcSlave">
+    <description>Bota Systems SensONE</description>
+  </class>
 </library>

--- a/ethercat_plugins/src/bota_plugins/sensone_ft_sensor.cpp
+++ b/ethercat_plugins/src/bota_plugins/sensone_ft_sensor.cpp
@@ -1,0 +1,102 @@
+#include <cstring>
+
+#include "ethercat_interface/ec_slave.hpp"
+#include "ethercat_plugins/commondefs.hpp"
+
+namespace ethercat_plugins {
+
+class SensOneFtSensor : public ethercat_interface::EcSlave {
+public:
+  SensOneFtSensor() : EcSlave(0x0000b07a, 0x00000001) {}
+  virtual ~SensOneFtSensor() {}
+  virtual void processData(size_t index, uint8_t* domain_address) {
+    if (data_index_[index] >= 0) {
+      uint32_t value = EC_READ_S32(domain_address);
+      float ret;
+      memcpy(&ret, &value, sizeof(float));
+      state_interface_ptr_->at(data_index_[index]) = static_cast<double>(ret);
+    }
+  }
+  virtual const ec_sync_info_t* syncs() { return &syncs_[0]; }
+  virtual size_t syncSize() {
+    return sizeof(syncs_) / sizeof(ec_sync_info_t);
+  }
+  virtual const ec_pdo_entry_info_t* channels() {
+    return channels_;
+  }
+  virtual void domains(DomainMap& domains) const {
+    domains = domains_;
+  }
+  virtual bool setupSlave(
+      std::unordered_map<std::string, std::string> slave_paramters, std::vector<double>* state_interface,
+      std::vector<double>* command_interface
+  ) {
+    state_interface_ptr_ = state_interface;
+    command_interface_ptr_ = command_interface;
+    paramters_ = slave_paramters;
+
+    if (paramters_.find("state_interface/force.x") != paramters_.end()) {
+      data_index_[1] = std::stoi(paramters_["state_interface/force.x"]);
+    }
+    if (paramters_.find("state_interface/force.y") != paramters_.end()) {
+      data_index_[2] = std::stoi(paramters_["state_interface/force.y"]);
+    }
+    if (paramters_.find("state_interface/force.z") != paramters_.end()) {
+      data_index_[3] = std::stoi(paramters_["state_interface/force.z"]);
+    }
+    if (paramters_.find("state_interface/torque.x") != paramters_.end()) {
+      data_index_[4] = std::stoi(paramters_["state_interface/torque.x"]);
+    }
+    if (paramters_.find("state_interface/torque.y") != paramters_.end()) {
+      data_index_[5] = std::stoi(paramters_["state_interface/torque.y"]);
+    }
+    if (paramters_.find("state_interface/torque.z") != paramters_.end()) {
+      data_index_[6] = std::stoi(paramters_["state_interface/torque.z"]);
+    }
+    return true;
+  }
+
+private:
+  int data_index_[7] = {-1, -1, -1, -1, -1, -1, -1};
+
+  ec_pdo_entry_info_t channels_[23] = {{0x7000, 0x00, 8}, /* Digital Output */
+                                       {0x6000, 0x01, 8}, /* Status */
+                                       {0x6000, 0x02, 32}, /* Warnings Errors Fatals */
+                                       {0x6000, 0x04, 32}, /* Force x */
+                                       {0x6000, 0x05, 32}, /* Force y */
+                                       {0x6000, 0x06, 32}, /* Force z */
+                                       {0x6000, 0x07, 32}, /* Torque x */
+                                       {0x6000, 0x08, 32}, /* Torque y */
+                                       {0x6000, 0x09, 32}, /* Torque z */
+                                       {0x6000, 0x0a, 16}, /* Force Torque Saturated */
+                                       {0x6000, 0x0b, 32}, /* Acceleration x */
+                                       {0x6000, 0x0c, 32}, /* Acceleration y */
+                                       {0x6000, 0x0d, 32}, /* Acceleration z */
+                                       {0x6000, 0x0e, 8}, /* Acceleration Saturated */
+                                       {0x6000, 0x0f, 32}, /* Angular Rate x */
+                                       {0x6000, 0x10, 32}, /* Angular Rate y */
+                                       {0x6000, 0x11, 32}, /* Angular Rate z */
+                                       {0x6000, 0x12, 8}, /* Angular Rate Saturated */
+                                       {0x6000, 0x13, 32}, /* Temperature */
+                                       {0x6000, 0x14, 32}, /* Orientation Estimate x */
+                                       {0x6000, 0x15, 32}, /* Orientation Estimate y */
+                                       {0x6000, 0x16, 32}, /* Orientation Estimate z */
+                                       {0x6000, 0x17, 32}, /* Orientation Estimate w */
+  };
+
+  ec_pdo_info_t pdos_[2] = {{0x1600, 1, channels_ + 0}, /* Digital Output */
+                            {0x1a00, 22, channels_ + 1}, /* Sensor Data */
+  };
+
+  ec_sync_info_t syncs_[5] = {{0, EC_DIR_OUTPUT, 0, NULL, EC_WD_DISABLE}, {1, EC_DIR_INPUT, 0, NULL, EC_WD_DISABLE},
+                              {2, EC_DIR_OUTPUT, 1, pdos_ + 0, EC_WD_DISABLE},
+                              {3, EC_DIR_INPUT, 1, pdos_ + 1, EC_WD_DISABLE}, {0xff}};
+
+  DomainMap domains_ = {{0, {0, 3, 4, 5, 6, 7, 8}}};
+};
+
+}  // namespace ethercat_plugins
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(ethercat_plugins::SensOneFtSensor, ethercat_interface::EcSlave)


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
- aica-technology/hardware-interfaces#75

<!-- Required: explain how the PR addresses the parent issue -->
Even though we said we'd go with the generic slave, I already have the SensONE plugin, so I think this can go to develop too. As mentioned earlier this week, the magic happens in `processData` and `setupSlave`. The private structures  (channels, pdos, syncs) can be generated from the device itself.

Interestingly, if we don't process the one RxPDO (digital out), the communication fails. Maybe that's a point that we can discuss with Bota in the future. What do I mean by that: If I do
```
DomainMap domains_ = {{0, {3, 4, 5, 6, 7, 8}}};
```
where 3,4,5,6,7,8 correspond to the channel indices of the wrench data, instead of
```
DomainMap domains_ = {{0, {0, 3, 4, 5, 6, 7, 8}}};
```
where the 0 index corresponds to the digital out, the plugin doesnt work. So somehow, even though other channels do not have to be processed (the `DomainMap` doesn't contain their indices), the RxPDO channel has to be.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 10 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->