### PR TITLE
Enable data type 'real' for generic slave

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*
+!ethercat_driver
+!ethercat_driver_ros2
+!ethercat_generic_plugins
+!ethercat_interface
+!ethercat_plugins
+!install_dependencies.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build/
 install/
 log/
 .vscode/
+.idea/
+cmake-build-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+ARG BASE_IMAGE_NAME=ghcr.io/aica-technology/ros2-modulo-control
+ARG BASE_IMAGE_TAG=humble
+FROM ${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG} as ws
+
+USER ${USER}
+SHELL ["/bin/bash", "-c"]
+
+# create a workspace
+ENV WORKSPACE=${HOME}/ethercat_ws
+RUN mkdir -p ${WORKSPACE}/src
+WORKDIR ${WORKSPACE}
+RUN source ${HOME}/ros2_ws/install/setup.bash; colcon build
+# source the new workspace on login
+RUN echo "source ${WORKSPACE}/install/setup.bash" | cat - ${HOME}/.bashrc > tmp && mv tmp ${HOME}/.bashrc
+
+WORKDIR /tmp
+COPY --chown=${USER} ./install_dependencies.sh ./install_dependencies.sh
+USER root
+RUN --mount=type=ssh ./install_dependencies.sh
+USER ${USER}
+
+
+FROM ws as development
+
+# copy the source folder in the workspace
+WORKDIR ${WORKSPACE}
+COPY --chown=${USER} . ./src/
+
+# clean image
+RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
+
+
+FROM development as production
+
+# build the component workspace
+RUN source ${HOME}/.bashrc; colcon build --symlink-install

--- a/build-server.sh
+++ b/build-server.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+BASE_IMAGE_NAME=ghcr.io/aica-technology/ros2-modulo-control
+BASE_IMAGE_TAG=humble-devel
+
+IMAGE_NAME=aica-technology/ethercat-driver-ros2
+IMAGE_TAG=latest
+
+SERVE_REMOTE=false
+REMOTE_SSH_PORT=3370
+
+HELP_MESSAGE="Usage: build-server.sh [-d] [-r] [-v] [-s]
+Options:
+  -d, --development               Only target the development layer to prevent
+                                  sources from being built or tested
+
+  -r, --rebuild                   Rebuild the image using the docker
+                                  --no-cache option
+
+  -v, --verbose                   Use the verbose option during the building
+                                  process
+
+  -s, --serve                     Start the remove development server
+"
+
+BUILD_FLAGS=()
+
+while [[ $# -gt 0 ]]; do
+  opt="$1"
+  case $opt in
+    -d|--development) BUILD_FLAGS+=(--target development) ; IMAGE_TAG=development ; shift 1 ;;
+    -r|--rebuild) BUILD_FLAGS+=(--no-cache) ; shift ;;
+    -v|--verbose) BUILD_FLAGS+=(--progress=plain) ; shift ;;
+    -s|--serve) SERVE_REMOTE=true ; shift ;;
+    -h|--help) echo "${HELP_MESSAGE}" ; exit 0 ;;
+    *) echo 'Error in command line parsing' >&2
+       echo -e "\n${HELP_MESSAGE}"
+       exit 1
+  esac
+done
+
+BUILD_FLAGS+=(--build-arg BASE_IMAGE_NAME="${BASE_IMAGE_NAME}")
+BUILD_FLAGS+=(--build-arg BASE_IMAGE_TAG="${BASE_IMAGE_TAG}")
+if [[ "$OSTYPE" != "darwin"* ]]; then
+  BUILD_FLAGS+=(--ssh default="${SSH_AUTH_SOCK}")
+else
+  BUILD_FLAGS+=(--ssh default="$HOME/.ssh/id_rsa")
+fi
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${IMAGE_TAG}")
+
+docker pull ${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}
+DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" . || exit 1
+
+if [ "${SERVE_REMOTE}" = true ]; then
+  aica-docker server "${IMAGE_NAME}:${IMAGE_TAG}" -u ros2 -p "${REMOTE_SSH_PORT}"
+fi

--- a/ethercat_generic_plugins/ethercat_generic_slave/src/generic_ec_slave.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_slave/src/generic_ec_slave.cpp
@@ -25,7 +25,7 @@ size_t type2bytes(std::string type)
     return 1;
   } else if (type == "int16" || type == "uint16") {
     return 2;
-  } else if (type == "int32" || type == "uint32") {
+  } else if (type == "int32" || type == "uint32" || type == "real") {
     return 4;
   } else if (type == "int64" || type == "uint64") {
     return 8;

--- a/ethercat_interface/include/ethercat_interface/ec_pdo_channel_manager.hpp
+++ b/ethercat_interface/include/ethercat_interface/ec_pdo_channel_manager.hpp
@@ -18,7 +18,8 @@
 #define ETHERCAT_INTERFACE__EC_PDO_CHANNEL_MANAGER_HPP_
 
 #include <ecrt.h>
-#include <string>
+#include <cstring>
+#include <iostream>
 #include <vector>
 #include <limits>
 
@@ -65,6 +66,11 @@ public:
       last_value = static_cast<double>(EC_READ_U64(domain_address));
     } else if (data_type == "int64") {
       last_value = static_cast<double>(EC_READ_S64(domain_address));
+    } else if (data_type == "real") {
+      uint32_t value = EC_READ_S32(domain_address);
+      float ret;
+      memcpy(&ret, &value, sizeof(float));
+      last_value = static_cast<double>(ret);
     } else {
       last_value = static_cast<double>(EC_READ_U8(domain_address) & data_mask);
     }
@@ -190,7 +196,7 @@ public:
       return 8;
     } else if (type == "int16" || type == "uint16") {
       return 16;
-    } else if (type == "int32" || type == "uint32") {
+    } else if (type == "int32" || type == "uint32" || type == "real") {
       return 32;
     } else if (type == "int64" || type == "uint64") {
       return 64;

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+apt-get update && apt-get install autoconf libtool -y || exit 1
+CURR_DIR=$(pwd)
+mkdir ec_dev && cd ec_dev && git clone https://gitlab.com/etherlab.org/ethercat.git || exit 1
+cd ethercat && git checkout stable-1.5 && ./bootstrap || exit 1
+./configure --prefix=/usr/local/etherlab --disable-8139too --disable-eoe --enable-generic --disable-kernel || exit 1
+make && make install && ldconfig || exit 1
+cd "${CURR_DIR}" && rm -rf ec_dev || exit 1


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
- #2 

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by adding the correct casting logic to interpret a uint32 as a double. Together with a couple of other PRs (hardware, backend) this will enable a generic interface for the SensONE

## Supporting information
Being able to use the generic slave will be super useful. Check [this guide](https://icube-robotics.github.io/ethercat_driver_ros2/user_guide/config_generic_slave.html) to see how it's used in practice.

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 10 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->