### PR TITLE
fix: check initialized on activate

### DIFF
--- a/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
@@ -41,6 +41,8 @@ class EthercatDriver : public hardware_interface::SystemInterface
 public:
   RCLCPP_SHARED_PTR_DEFINITIONS(EthercatDriver)
 
+  ~EthercatDriver() override;
+
   ETHERCAT_DRIVER_PUBLIC
   CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
 
@@ -89,6 +91,7 @@ private:
   ethercat_interface::EcMaster master_;
   std::mutex ec_mutex_;
   bool activated_;
+  int activation_timeout_;
 };
 }  // namespace ethercat_driver
 

--- a/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
@@ -91,7 +91,7 @@ private:
   ethercat_interface::EcMaster master_;
   std::mutex ec_mutex_;
   bool activated_;
-  int activation_timeout_;
+  double activation_timeout_;
 };
 }  // namespace ethercat_driver
 

--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -335,6 +335,7 @@ CallbackReturn EthercatDriver::on_activate(
     RCLCPP_ERROR(rclcpp::get_logger("EthercatDriver"), "Activate EcMaster failed");
     return CallbackReturn::ERROR;
   }
+  activated_ = true;
   RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "Activated EcMaster!");
 
   // start after one second
@@ -365,8 +366,6 @@ CallbackReturn EthercatDriver::on_activate(
 
   RCLCPP_INFO(
     rclcpp::get_logger("EthercatDriver"), "System Successfully started!");
-
-  activated_ = true;
 
   return CallbackReturn::SUCCESS;
 }

--- a/ethercat_interface/include/ethercat_interface/ec_slave.hpp
+++ b/ethercat_interface/include/ethercat_interface/ec_slave.hpp
@@ -40,6 +40,7 @@ public:
   /** a pointer to syncs. return &syncs[0] */
   virtual const ec_sync_info_t * syncs() {return NULL;}
   virtual bool initialized() {return true;}
+  virtual bool operational() {return is_operational_;}
   virtual void set_state_is_operational(bool value) {is_operational_ = value;}
   /** Assign activate DC synchronization. return activate word*/
   virtual int assign_activate_dc_sync() {return 0x00;}

--- a/ethercat_interface/include/ethercat_interface/ec_slave.hpp
+++ b/ethercat_interface/include/ethercat_interface/ec_slave.hpp
@@ -40,7 +40,6 @@ public:
   /** a pointer to syncs. return &syncs[0] */
   virtual const ec_sync_info_t * syncs() {return NULL;}
   virtual bool initialized() {return true;}
-  virtual bool operational() {return is_operational_;}
   virtual void set_state_is_operational(bool value) {is_operational_ = value;}
   /** Assign activate DC synchronization. return activate word*/
   virtual int assign_activate_dc_sync() {return 0x00;}

--- a/ethercat_plugins/ethercat_bota_modules/src/bota_ft_sensor.cpp
+++ b/ethercat_plugins/ethercat_bota_modules/src/bota_ft_sensor.cpp
@@ -8,6 +8,7 @@ class BotaFtSensor : public ethercat_interface::EcSlave {
 public:
   BotaFtSensor() : EcSlave(0x0000b07a, 0x00000001) {}
   virtual ~BotaFtSensor() {}
+  virtual bool initialized() { return is_operational_; }
   virtual void processData(size_t index, uint8_t* domain_address) {
     if (data_index_[index] >= 0) {
       uint32_t value = EC_READ_S32(domain_address);


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
Here I'm fixing an issue where `on_activate` of the ethercat driver hardware interface, it would check the `initialized` method of slaves to determine if the driver should be activated. Two problems:
1. This method was not overridden for the bota slave
2. This would check forever if the slave is not connected, I made the while loop into a conditional with a timeout.

Additionally, I override the desctructor to avoid shutdown warnings when activation fails

<!-- Required: explain how the PR addresses the parent issue -->

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->